### PR TITLE
Refactor AST logic

### DIFF
--- a/packages/hekla-core/src/utils/ast-utils/index.js
+++ b/packages/hekla-core/src/utils/ast-utils/index.js
@@ -41,9 +41,14 @@ function filterNodes(tree, filterFunction) {
 }
 
 function isPromiseCall(callExpNode) {
-  return (callExpNode.callee.property &&
-    callExpNode.callee.property.type === 'Identifier' &&
-    callExpNode.callee.property.name === 'then');
+  return looksLike(callExpNode, {
+    callee: {
+      property: {
+        type: 'Identifier',
+        name: 'then'
+      }
+    }
+  });
 }
 
 function isASTNode(value, key, parent) {

--- a/packages/hekla-core/src/utils/ast-utils/index.js
+++ b/packages/hekla-core/src/utils/ast-utils/index.js
@@ -10,6 +10,7 @@ module.exports = {
   filterNodes,
   isPromiseCall,
   isASTNode,
+  looksLike,
   getDeepProperty,
   reduceCallName,
   reduceMemberName,
@@ -47,6 +48,25 @@ function isPromiseCall(callExpNode) {
 
 function isASTNode(value, key, parent) {
   return (value && typeof value === 'object' && value.type);
+}
+
+function looksLike(a, b) {
+  return (
+    a &&
+    b &&
+    Object.keys(b).every(bKey => {
+      const bVal = b[bKey]
+      const aVal = a[bKey]
+      if (typeof bVal === 'function') {
+        return bVal(aVal)
+      }
+      return isPrimitive(bVal) ? bVal === aVal : looksLike(aVal, bVal)
+    })
+  )
+}
+
+function isPrimitive(val) {
+  return val == null || /^[sbn]/.test(typeof val)
 }
 
 /**

--- a/packages/hekla-core/src/utils/ast-utils/index.spec.js
+++ b/packages/hekla-core/src/utils/ast-utils/index.spec.js
@@ -9,7 +9,94 @@ function parse(filename) {
   return astUtils.parseAST(contents, filePath);
 }
 
+// const x = 5;
+const AST_VARIABLE_ASSIGNMENT = {
+  type: 'VariableDeclaration',
+  declarations: [
+    {
+      type: 'VariableDeclarator',
+      id: {
+        type: 'Identifier',
+        name: 'x'
+      },
+      init: {
+        type: 'NumericLiteral',
+        value: 5
+      }
+    }
+  ],
+  kind: 'const'
+};
+
+// function add(x, y) {
+//   return x + y;
+// }
+const AST_FUNCTION_DECLARATION = {
+  type: 'FunctionDeclaration',
+  id: {
+    type: 'Identifier',
+    name: 'add'
+  },
+  generator: false,
+  expression: false,
+  async: false,
+  params: [
+    {
+      type: 'Identifier',
+      name: 'x'
+    },
+    {
+      type: 'Identifier',
+      name: 'y'
+    }
+  ],
+  body: {
+    type: 'BlockStatement',
+    body: [
+      {
+        type: 'ReturnStatement',
+        argument: {
+          type: 'BinaryExpression',
+          left: {
+            type: 'Identifier',
+            name: 'x'
+          },
+          operator: '+',
+          right: {
+            type: 'Identifier',
+            name: 'y'
+          }
+        }
+      }
+    ],
+    directives: []
+  }
+};
+
 describe('astUtils', () => {
+
+  describe('looksLike', () => {
+    const { looksLike } = astUtils;
+
+    it('should work on partial AST node definitions', () => {
+      expect(looksLike(AST_VARIABLE_ASSIGNMENT, {
+        type: 'VariableDeclaration',
+        kind: 'const'
+      })).to.be.true;
+      expect(looksLike(AST_VARIABLE_ASSIGNMENT.declarations[0], {
+        type: 'VariableDeclarator',
+        id: {},
+        init: {}
+      })).to.be.true;
+      expect(looksLike(AST_VARIABLE_ASSIGNMENT.declarations[0].id, {
+        type: 'Identifier',
+        name: 'x'
+      })).to.be.true;
+      expect(looksLike(AST_VARIABLE_ASSIGNMENT.declarations[0].id, {
+        name: 'truck'
+      })).to.be.false;
+    });
+  });
 
   describe('getImportInfo', () => {
 


### PR DESCRIPTION
This adds a new `looksLike` function in astUtils, which can be used to compare AST nodes in a more declarative way, rather than difficult-to-read conditions. This will help the analysis code stay approachable and maintainable.