### PR TITLE
Drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 
 node_js:
   - "8"
-  - "6"


### PR DESCRIPTION
This removes the Travis build for Node 6. We don't want to support it anymore, because it is no longer in LTS and it prevents us from using more modern JS syntax.