### PR TITLE
Create plugin system

### DIFF
--- a/packages/hekla-core/package-lock.json
+++ b/packages/hekla-core/package-lock.json
@@ -9,6 +9,16 @@
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
 			"integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg=="
 		},
+		"@babel/types": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.2.tgz",
+			"integrity": "sha512-pb1I05sZEKiSlMUV9UReaqsCPUpgbHHHu2n1piRm7JkuBkm6QxcaIzKu6FMnMtCbih/cEYTR+RGYYC96Yk9HAg==",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.10",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -165,6 +175,11 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -386,6 +401,11 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
 			"integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA=="
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"tree-walk": {
 			"version": "0.4.0",

--- a/packages/hekla-core/package.json
+++ b/packages/hekla-core/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/parser": "^7.0.0",
+    "@babel/types": "^7.1.2",
     "async": "^2.1.2",
     "camel-case": "^3.0.0",
     "dashify": "^0.2.2",

--- a/packages/hekla-core/package.json
+++ b/packages/hekla-core/package.json
@@ -14,6 +14,7 @@
     "async": "^2.1.2",
     "camel-case": "^3.0.0",
     "dashify": "^0.2.2",
+    "domhandler": "^2.4.2",
     "glob": "^7.0.5",
     "htmlparser2": "^3.9.1",
     "tapable": "^1.1.0",

--- a/packages/hekla-core/src/Analyzer.js
+++ b/packages/hekla-core/src/Analyzer.js
@@ -18,8 +18,8 @@ module.exports = class Analyzer {
     this.modules = [];
     this.hooks = {
       moduleRawSource: new SyncHook(['module', 'source']),
-      moduleJSFamilyAST: new SyncHook(['module', 'ast']),
-      moduleHTMLFamilyDOM: new SyncHook(['module', 'dom']),
+      moduleSyntaxTreeJS: new SyncHook(['module', 'ast']),
+      moduleSyntaxTreeHTML: new SyncHook(['module', 'dom']),
       reporter: new AsyncSeriesHook(['analyzer', 'analysis'])
     };
   }
@@ -77,13 +77,13 @@ module.exports = class Analyzer {
       return parseAST(contents)
         .then(ast => {
           const astWrapper = new ASTWrapper(ast);
-          this.hooks.moduleJSFamilyAST.call(module, astWrapper);
+          this.hooks.moduleSyntaxTreeJS.call(module, astWrapper);
         });
     } else if (resource.match(/\.html$/)) {
       return parseHTML(contents)
         .then(dom => {
           const domWrapper = new DOMWrapper(dom);
-          this.hooks.moduleHTMLFamilyDOM.call(module, domWrapper);
+          this.hooks.moduleSyntaxTreeHTML.call(module, domWrapper);
         });
     } else {
       // This file type doesn't support parsing its AST.

--- a/packages/hekla-core/src/Analyzer.js
+++ b/packages/hekla-core/src/Analyzer.js
@@ -1,4 +1,7 @@
-const { SyncHook } = require('tapable');
+const {
+  SyncHook,
+  AsyncSeriesHook
+} = require('tapable');
 
 const Module = require('./Module');
 const {
@@ -12,7 +15,8 @@ module.exports = class Analyzer {
     this.modules = [];
     this.hooks = {
       moduleRawSource: new SyncHook(['module', 'source']),
-      moduleJSFamilyAST: new SyncHook(['module', 'ast'])
+      moduleJSFamilyAST: new SyncHook(['module', 'ast']),
+      reporter: new AsyncSeriesHook(['analyzer', 'analysis'])
     };
   }
 
@@ -77,6 +81,10 @@ module.exports = class Analyzer {
 
   processJSModuleAST(module, ast) {
     this.hooks.moduleJSFamilyAST.call(module, ast);
+  }
+
+  processReporters(analysis) {
+    return this.hooks.reporter.promise(this, analysis);
   }
 }
 

--- a/packages/hekla-core/src/Analyzer.js
+++ b/packages/hekla-core/src/Analyzer.js
@@ -5,7 +5,8 @@ const {
 
 const Module = require('./Module');
 const {
-  parseAST
+  parseAST,
+  parseHTML
 } = require('./utils/ast-utils');
 
 module.exports = class Analyzer {

--- a/packages/hekla-core/src/Analyzer.js
+++ b/packages/hekla-core/src/Analyzer.js
@@ -7,6 +7,7 @@ const Module = require('./Module');
 const {
   parseAST,
   parseHTML,
+  ASTWrapper,
   DOMWrapper
 } = require('./utils/ast-utils');
 
@@ -75,7 +76,8 @@ module.exports = class Analyzer {
     if (resource.match(/\.[jt]sx?$/)) {
       return parseAST(contents)
         .then(ast => {
-          this.hooks.moduleJSFamilyAST.call(module, ast);
+          const astWrapper = new ASTWrapper(ast);
+          this.hooks.moduleJSFamilyAST.call(module, astWrapper);
         });
     } else if (resource.match(/\.html$/)) {
       return parseHTML(contents)

--- a/packages/hekla-core/src/plugins/ListImportsPlugin.js
+++ b/packages/hekla-core/src/plugins/ListImportsPlugin.js
@@ -2,10 +2,10 @@ const { getImportInfo } = require('../utils/ast-utils');
 
 module.exports = class ListImportsPlugin {
   apply(analyzer) {
-    analyzer.hooks.moduleJSFamilyAST.tap('ListImportsPlugin', this.moduleJSFamilyAST.bind(this));
+    analyzer.hooks.moduleSyntaxTreeJS.tap('ListImportsPlugin', this.moduleSyntaxTreeJS.bind(this));
   }
 
-  moduleJSFamilyAST(module, ast) {
+  moduleSyntaxTreeJS(module, ast) {
     const imports = getImportInfo(ast.unwrap());
     module.set('imports', imports);
   }

--- a/packages/hekla-core/src/plugins/ListImportsPlugin.js
+++ b/packages/hekla-core/src/plugins/ListImportsPlugin.js
@@ -6,7 +6,7 @@ module.exports = class ListImportsPlugin {
   }
 
   moduleJSFamilyAST(module, ast) {
-    const imports = getImportInfo(ast);
+    const imports = getImportInfo(ast.unwrap());
     module.set('imports', imports);
   }
 }

--- a/packages/hekla-core/src/utils/ast-utils/ASTWrapper.js
+++ b/packages/hekla-core/src/utils/ast-utils/ASTWrapper.js
@@ -1,4 +1,8 @@
 const walk = require('tree-walk');
+const { VISITOR_KEYS } = require('@babel/types');
+
+// TODO: define a custom walker based on VISITOR_KEYS
+// (See DOMWalker)
 
 module.exports = class ASTWrapper {
   constructor(ast) {
@@ -7,5 +11,24 @@ module.exports = class ASTWrapper {
 
   unwrap() {
     return this.ast;
+  }
+
+  visit(visitors) {
+    for (let key in visitors) {
+      if (!VISITOR_KEYS.hasOwnProperty(key)) {
+        throw new TypeError(`Invalid visitor type: ${key}`);
+      }
+    }
+
+    walk.preorder(this.ast, (node) => callVisitor(node, visitors, this.ast));
+  }
+}
+
+function callVisitor(node, visitors, dom) {
+  if (!node) {
+    return;
+  }
+  if (node.type && visitors[node.type]) {
+    visitors[node.type](node);
   }
 }

--- a/packages/hekla-core/src/utils/ast-utils/ASTWrapper.js
+++ b/packages/hekla-core/src/utils/ast-utils/ASTWrapper.js
@@ -1,0 +1,11 @@
+const walk = require('tree-walk');
+
+module.exports = class ASTWrapper {
+  constructor(ast) {
+    this.ast = ast;
+  }
+
+  unwrap() {
+    return this.ast;
+  }
+}

--- a/packages/hekla-core/src/utils/ast-utils/ASTWrapper.spec.js
+++ b/packages/hekla-core/src/utils/ast-utils/ASTWrapper.spec.js
@@ -1,0 +1,17 @@
+const ASTWrapper = require('./ASTWrapper');
+const { parseAST } = require('./index');
+
+describe('ASTWrapper', () => {
+
+  describe('unwrap', () => {
+
+    it('should return the AST it wraps', async () => {
+      const js = `console.log('hello world')`;
+      const ast = await parseAST(js);
+      const wrapper = new ASTWrapper(ast);
+      expect(wrapper.unwrap()).to.equal(ast);
+    });
+
+  });
+
+});

--- a/packages/hekla-core/src/utils/ast-utils/ASTWrapper.spec.js
+++ b/packages/hekla-core/src/utils/ast-utils/ASTWrapper.spec.js
@@ -14,4 +14,77 @@ describe('ASTWrapper', () => {
 
   });
 
+  describe('visit', () => {
+
+    it('should call the visitor when it finds a matching node', async () => {
+      const js = `console.log('hello world')`;
+      const ast = await parseAST(js);
+      const wrapper = new ASTWrapper(ast);
+      const identifiers = [];
+      wrapper.visit({
+        Identifier(node) {
+          identifiers.push(node.name);
+        }
+      });
+      expect(identifiers).to.deep.equal(['console', 'log'])
+    });
+
+    it('should work for FunctionDeclaration nodes', async () => {
+      const js = `
+        function add(x, y) {
+          return x + y;
+        }
+      `;
+      const ast = await parseAST(js);
+      const wrapper = new ASTWrapper(ast);
+      let functionNode = null;
+      wrapper.visit({
+        FunctionDeclaration(node) {
+          functionNode = node;
+        }
+      });
+      expect(functionNode).to.not.be.undefined;
+      expect(functionNode.id.type).to.equal('Identifier');
+      expect(functionNode.id.name).to.equal('add');
+    });
+
+    it('should work for multiple visitors at the same time', async () => {
+      const js = `
+        function add(x, y) {
+          return x + y;
+        }
+
+        function sub(x, y) {
+          return x - y;
+        }
+      `;
+      const ast = await parseAST(js);
+      const wrapper = new ASTWrapper(ast);
+      let functions = 0;
+      const identifiers = [];
+      wrapper.visit({
+        FunctionDeclaration(node) {
+          functions++;
+        },
+        Identifier(node) {
+          identifiers.push(node.name);
+        }
+      });
+      expect(functions).to.equal(2);
+      expect(identifiers).to.deep.equal([
+        'add',
+        'x',
+        'y',
+        'x',
+        'y',
+        'sub',
+        'x',
+        'y',
+        'x',
+        'y',
+      ]);
+    });
+
+  });
+
 });

--- a/packages/hekla-core/src/utils/ast-utils/DOMWrapper.js
+++ b/packages/hekla-core/src/utils/ast-utils/DOMWrapper.js
@@ -38,30 +38,23 @@ module.exports = class DOMWrapper {
       }
     }
 
-    domWalker.preorder(this.dom, (node) => this.delegate(node, visitors));
+    domWalker.preorder(this.dom, (node) => callVisitor(node, visitors, this.dom));
+  }
+}
+
+function callVisitor(node, visitors, dom) {
+  if (node === dom) {
+    // Skip the root-level array of nodes, wait to visit each actual node
+    return;
   }
 
-  addVisitor(type, callback) {
-    if (!this.visitors[type]) {
-      this.visitors[type] = [];
-    }
-    this.visitors[type].push(callback);
+  if (!node || !node.type) {
+    throw new TypeError('Unrecognized tree node');
   }
 
-  delegate(node, visitors) {
-    if (node === this.dom) {
-      // Skip the root-level array of nodes, wait to visit each actual node
-      return;
-    }
-
-    if (!node || !node.type) {
-      throw new TypeError('Unrecognized tree node');
-    }
-
-    if (node.type === 'tag' && visitors['tag']) {
-      visitors['tag'](node);
-    } else if (node.type === 'text' && visitors['text']) {
-      visitors['text'](node);
-    }
+  if (node.type === 'tag' && visitors['tag']) {
+    visitors['tag'](node);
+  } else if (node.type === 'text' && visitors['text']) {
+    visitors['text'](node);
   }
 }

--- a/packages/hekla-core/src/utils/ast-utils/DOMWrapper.js
+++ b/packages/hekla-core/src/utils/ast-utils/DOMWrapper.js
@@ -1,5 +1,12 @@
 const walk = require('tree-walk');
 
+const NODE_TYPES = [
+  'tag',
+  'text',
+  'comment',
+  'directive'
+];
+
 const domWalker = walk(el => {
   // https://www.npmjs.com/package/tree-walk#custom-walkers
   if (Array.isArray(el)) {
@@ -25,6 +32,12 @@ module.exports = class DOMWrapper {
   }
 
   visit(visitors) {
+    for (let key in visitors) {
+      if (!NODE_TYPES.includes(key)) {
+        throw new TypeError(`Invalid visitor type: ${key}`);
+      }
+    }
+
     domWalker.preorder(this.dom, (node) => this.delegate(node, visitors));
   }
 

--- a/packages/hekla-core/src/utils/ast-utils/DOMWrapper.js
+++ b/packages/hekla-core/src/utils/ast-utils/DOMWrapper.js
@@ -18,20 +18,14 @@ const domWalker = walk(el => {
 module.exports = class DOMWrapper {
   constructor(dom) {
     this.dom = dom;
-    this.visitors = {};
   }
 
   unwrap() {
     return this.dom;
   }
 
-  visit(callbacks) {
-    if (callbacks.tag) {
-      this.addVisitor('tag', callbacks.tag);
-    }
-    if (callbacks.text) {
-      this.addVisitor('text', callbacks.text);
-    }
+  visit(visitors) {
+    domWalker.preorder(this.dom, (node) => this.delegate(node, visitors));
   }
 
   addVisitor(type, callback) {
@@ -41,11 +35,7 @@ module.exports = class DOMWrapper {
     this.visitors[type].push(callback);
   }
 
-  walk() {
-    domWalker.preorder(this.dom, (node) => this.delegate(node));
-  }
-
-  delegate(node) {
+  delegate(node, visitors) {
     if (node === this.dom) {
       // Skip the root-level array of nodes, wait to visit each actual node
       return;
@@ -55,14 +45,10 @@ module.exports = class DOMWrapper {
       throw new TypeError('Unrecognized tree node');
     }
 
-    if (node.type === 'tag' && this.visitors['tag']) {
-      for (let childVisitor of this.visitors['tag']) {
-        childVisitor(node);
-      }
-    } else if (node.type === 'text' && this.visitors['text']) {
-      for (let childVisitor of this.visitors['text']) {
-        childVisitor(node);
-      }
+    if (node.type === 'tag' && visitors['tag']) {
+      visitors['tag'](node);
+    } else if (node.type === 'text' && visitors['text']) {
+      visitors['text'](node);
     }
   }
 }

--- a/packages/hekla-core/src/utils/ast-utils/DOMWrapper.js
+++ b/packages/hekla-core/src/utils/ast-utils/DOMWrapper.js
@@ -1,0 +1,68 @@
+const walk = require('tree-walk');
+
+const domWalker = walk(el => {
+  // https://www.npmjs.com/package/tree-walk#custom-walkers
+  if (Array.isArray(el)) {
+    return el;
+  } else if (el.type) {
+    if (el.children) {
+      return el.children;
+    } else {
+      return [];
+    }
+  } else {
+    throw new TypeError('Unrecognized tree node');
+  }
+});
+
+module.exports = class DOMWrapper {
+  constructor(dom) {
+    this.dom = dom;
+    this.visitors = {};
+  }
+
+  unwrap() {
+    return this.dom;
+  }
+
+  visit(callbacks) {
+    if (callbacks.tag) {
+      this.addVisitor('tag', callbacks.tag);
+    }
+    if (callbacks.text) {
+      this.addVisitor('text', callbacks.text);
+    }
+  }
+
+  addVisitor(type, callback) {
+    if (!this.visitors[type]) {
+      this.visitors[type] = [];
+    }
+    this.visitors[type].push(callback);
+  }
+
+  walk() {
+    domWalker.preorder(this.dom, (node) => this.delegate(node));
+  }
+
+  delegate(node) {
+    if (node === this.dom) {
+      // Skip the root-level array of nodes, wait to visit each actual node
+      return;
+    }
+
+    if (!node || !node.type) {
+      throw new TypeError('Unrecognized tree node');
+    }
+
+    if (node.type === 'tag' && this.visitors['tag']) {
+      for (let childVisitor of this.visitors['tag']) {
+        childVisitor(node);
+      }
+    } else if (node.type === 'text' && this.visitors['text']) {
+      for (let childVisitor of this.visitors['text']) {
+        childVisitor(node);
+      }
+    }
+  }
+}

--- a/packages/hekla-core/src/utils/ast-utils/DOMWrapper.spec.js
+++ b/packages/hekla-core/src/utils/ast-utils/DOMWrapper.spec.js
@@ -69,6 +69,17 @@ describe('DOMWrapper', () => {
       expect(fullText).to.equal('Hello world');
     });
 
+    it('should reject visitors for node types that do not exist', async () => {
+      const html = '<div>Hello <b>world</b></div>';
+      const dom = await parseHTML(html);
+      const wrapper = new DOMWrapper(dom);
+      expect(() => {
+        wrapper.visit({
+          truck: (node) => {}
+        });
+      }).to.throw('Invalid visitor type: truck');
+    });
+
   });
 
 });

--- a/packages/hekla-core/src/utils/ast-utils/DOMWrapper.spec.js
+++ b/packages/hekla-core/src/utils/ast-utils/DOMWrapper.spec.js
@@ -1,0 +1,77 @@
+const DOMWrapper = require('./DOMWrapper');
+const { parseHTML } = require('./index');
+
+describe('DOMWrapper', () => {
+
+  describe('unwrap', () => {
+
+    it('should return the DOM it wraps', async () => {
+      const html = '<div>Hello <b>world</b></div>';
+      const dom = await parseHTML(html);
+      const wrapper = new DOMWrapper(dom);
+      expect(wrapper.unwrap()).to.equal(dom);
+    });
+
+  });
+
+  describe('visit', () => {
+
+    it('should call the visitor on each tag', async () => {
+      const html = '<div>Hello <b>world</b></div>';
+      const dom = await parseHTML(html);
+      const wrapper = new DOMWrapper(dom);
+      const foundTags = [];
+      wrapper.visit({
+        tag: (node) => {
+          foundTags.push(node.name);
+        }
+      });
+      wrapper.walk();
+      expect(foundTags).to.deep.equal(['div', 'b']);
+    });
+
+    it('should call the visitor on each text node', async () => {
+      const html = '<div>Hello <b>world</b></div>';
+      const dom = await parseHTML(html);
+      const wrapper = new DOMWrapper(dom);
+      let fullText = '';
+      wrapper.visit({
+        text: (node) => {
+          fullText += node.data;
+        }
+      });
+      wrapper.walk();
+      expect(fullText).to.equal('Hello world');
+    });
+
+    it('should handle multiple visitors', async () => {
+      const html = '<div>Hello <b>world</b></div>';
+      const dom = await parseHTML(html);
+      const wrapper = new DOMWrapper(dom);
+
+      // Learn lots of things about the tree in a single pass
+      let foundTags = [];
+      let tagCount = 0;
+      let fullText = '';
+      wrapper.visit({
+        tag: (node) => {
+          foundTags.push(node.name);
+        }
+      });
+      wrapper.visit({
+        tag: (node) => {
+          tagCount++;
+        },
+        text: (node) => {
+          fullText += node.data;
+        }
+      });
+      wrapper.walk();
+      expect(foundTags).to.deep.equal(['div', 'b']);
+      expect(tagCount).to.equal(2);
+      expect(fullText).to.equal('Hello world');
+    });
+
+  });
+
+});

--- a/packages/hekla-core/src/utils/ast-utils/DOMWrapper.spec.js
+++ b/packages/hekla-core/src/utils/ast-utils/DOMWrapper.spec.js
@@ -26,7 +26,6 @@ describe('DOMWrapper', () => {
           foundTags.push(node.name);
         }
       });
-      wrapper.walk();
       expect(foundTags).to.deep.equal(['div', 'b']);
     });
 
@@ -40,7 +39,6 @@ describe('DOMWrapper', () => {
           fullText += node.data;
         }
       });
-      wrapper.walk();
       expect(fullText).to.equal('Hello world');
     });
 
@@ -66,7 +64,6 @@ describe('DOMWrapper', () => {
           fullText += node.data;
         }
       });
-      wrapper.walk();
       expect(foundTags).to.deep.equal(['div', 'b']);
       expect(tagCount).to.equal(2);
       expect(fullText).to.equal('Hello world');

--- a/packages/hekla-core/src/utils/ast-utils/index.js
+++ b/packages/hekla-core/src/utils/ast-utils/index.js
@@ -2,10 +2,13 @@
 
 const path = require('path');
 const babelParser = require('@babel/parser');
+const HtmlParser = require('htmlparser2').Parser;
+const DomHandler = require('domhandler');
 const walk = require('tree-walk');
 
 module.exports = {
   parseAST,
+  parseHTML,
   getNodesByType,
   filterNodes,
   isPromiseCall,
@@ -37,6 +40,26 @@ function parseAST(fileContents, filePath) {
   } catch (err) {
     return Promise.reject(err);
   }
+}
+
+function parseHTML(source) {
+  return new Promise((resolve, reject) => {
+    try {
+      const handler = new DomHandler((err, dom) => {
+        if (err) {
+          return reject(err);
+        } else {
+          return resolve(dom);
+        }
+      });
+      const options = {};
+      const parser = new HtmlParser(handler, options);
+      parser.write(source);
+      parser.end();
+    } catch (err) {
+      reject(err);
+    }
+  });
 }
 
 function getNodesByType(tree, nodeType) {

--- a/packages/hekla-core/src/utils/ast-utils/index.js
+++ b/packages/hekla-core/src/utils/ast-utils/index.js
@@ -6,9 +6,12 @@ const HtmlParser = require('htmlparser2').Parser;
 const DomHandler = require('domhandler');
 const walk = require('tree-walk');
 
+const DOMWrapper = require('./DOMWrapper');
+
 module.exports = {
   parseAST,
   parseHTML,
+  DOMWrapper,
   getNodesByType,
   filterNodes,
   isPromiseCall,

--- a/packages/hekla-core/src/utils/ast-utils/index.js
+++ b/packages/hekla-core/src/utils/ast-utils/index.js
@@ -6,11 +6,13 @@ const HtmlParser = require('htmlparser2').Parser;
 const DomHandler = require('domhandler');
 const walk = require('tree-walk');
 
+const ASTWrapper = require('./ASTWrapper');
 const DOMWrapper = require('./DOMWrapper');
 
 module.exports = {
   parseAST,
   parseHTML,
+  ASTWrapper,
   DOMWrapper,
   getNodesByType,
   filterNodes,

--- a/packages/hekla-core/src/utils/ast-utils/index.spec.js
+++ b/packages/hekla-core/src/utils/ast-utils/index.spec.js
@@ -75,6 +75,57 @@ const AST_FUNCTION_DECLARATION = {
 
 describe('astUtils', () => {
 
+  describe('parseHTML', () => {
+
+    it('should parse a simple HTML string', async () => {
+      const html = `<div>Hello <b>world</b></div>`;
+      const dom = await astUtils.parseHTML(html);
+
+      expect(dom).to.be.an('array');
+      expect(dom).to.have.lengthOf(1);
+
+      const div = dom[0];
+      expect(div.type).to.equal('tag');
+      expect(div.name).to.equal('div');
+      expect(div.children).to.have.lengthOf(2);
+
+      const [text, bold] = div.children;
+
+      expect(text.type).to.equal('text');
+      expect(text.data).to.equal('Hello ');
+
+      expect(bold.type).to.equal('tag');
+      expect(bold.name).to.equal('b');
+      expect(bold.children).to.have.lengthOf(1);
+
+      const world = bold.children[0];
+      expect(world.type).to.equal('text');
+      expect(world.data).to.equal('world');
+    });
+
+    it('should parse HTML with attributes', async () => {
+      const html = `<div class="special" data-special>Special</div>`;
+      const dom = await astUtils.parseHTML(html);
+
+      expect(dom).to.be.an('array');
+      expect(dom).to.have.lengthOf(1);
+
+      const div = dom[0];
+      expect(div.type).to.equal('tag');
+      expect(div.name).to.equal('div');
+      expect(div.children).to.have.lengthOf(1);
+
+      const { attribs } = div;
+      expect(attribs['class']).to.equal('special');
+      expect(attribs['data-special']).to.equal('');
+
+      const text = div.children[0];
+      expect(text.type).to.equal('text');
+      expect(text.data).to.equal('Special');
+    });
+
+  });
+
   describe('looksLike', () => {
     const { looksLike } = astUtils;
 

--- a/packages/hekla-webpack-plugin/src/HeklaWebpackPlugin.js
+++ b/packages/hekla-webpack-plugin/src/HeklaWebpackPlugin.js
@@ -87,9 +87,13 @@ module.exports = class HeklaWebpackPlugin {
   }
 
   emit(compilation, done) {
+    let analysis;
     this.waitForQueueDrain()
       .then(() => {
-        const analysis = this.analyzer.getAnalysis();
+        analysis = this.analyzer.getAnalysis();
+        return this.analyzer.processReporters(analysis);
+      })
+      .then(() => {
         const analysisFile = JSON.stringify(analysis, null, 2);
 
         compilation.assets['analysis.json'] = {

--- a/packages/hekla-webpack-plugin/src/HeklaWebpackPlugin.js
+++ b/packages/hekla-webpack-plugin/src/HeklaWebpackPlugin.js
@@ -43,7 +43,7 @@ module.exports = class HeklaWebpackPlugin {
 
     this.analyzer.applyConfig(this.config);
 
-    compiler.hooks.emit.tapAsync('AnalysisPlugin', this.emit.bind(this));
+    compiler.hooks.emit.tapPromise('AnalysisPlugin', this.emit.bind(this));
 
     compiler.hooks.compilation.tap('AnalysisPlugin', (compilation) => {
       this.analyzer.setInputFileSystem(compilation.inputFileSystem);
@@ -86,9 +86,9 @@ module.exports = class HeklaWebpackPlugin {
     this.queue.push(makeTask(moduleName, sanitizedResource));
   }
 
-  emit(compilation, done) {
+  emit(compilation) {
     let analysis;
-    this.waitForQueueDrain()
+    return this.waitForQueueDrain()
       .then(() => {
         analysis = this.analyzer.getAnalysis();
         return this.analyzer.processReporters(analysis);
@@ -104,12 +104,10 @@ module.exports = class HeklaWebpackPlugin {
             return analysisFile.length;
           }
         };
-
-        done();
       })
       .catch(err => {
         console.error('Error waiting for analysis:', err);
-        done(err);
+        throw err;
       });
   }
 


### PR DESCRIPTION
Previous commits started a plugin system in hekla-core, and this PR expands it into something more production-ready.

Hooks:

- `moduleRawSource`, for working with the raw source code of a file, as a string
- `moduleSyntaxTreeJS`, for working with the AST of a JS/TS file
- `moduleSyntaxTreeHTML`, for working with the DOM of an HTML file
- `reporter`, for reporting analysis results to files or web APIs

Note that syntax trees are handled using new `ASTWrapper` and `DOMWrapper` classes, which create an easy interface for the visitor pattern.

Resolves #5.