### PR TITLE
Add shortName property to Modules

### DIFF
--- a/packages/hekla-core/src/Analyzer.js
+++ b/packages/hekla-core/src/Analyzer.js
@@ -5,6 +5,9 @@ const {
 
 const Module = require('./Module');
 const {
+  getModuleName
+} = require('./utils/fs-utils');
+const {
   parseAST,
   parseHTML,
   ASTWrapper,
@@ -38,10 +41,6 @@ module.exports = class Analyzer {
     this.fs = fs;
   }
 
-  getModuleName(resource) {
-    return getModuleName(resource, this.rootPath);
-  }
-
   getAnalysis() {
     const analysis = {
       modules: this.modules.map(module => module.serialize())
@@ -50,7 +49,7 @@ module.exports = class Analyzer {
   }
 
   createModule(resource) {
-    const moduleName = this.getModuleName(resource);
+    const moduleName = getModuleName(resource, this.rootPath);
     return new Module(moduleName, resource);
   }
 
@@ -111,14 +110,4 @@ function readFile(fs, filename) {
       }
     });
   });
-}
-
-function getModuleName(resource, rootPath) {
-  let fullPath = resource;
-  if (fullPath.indexOf('!') !== -1) {
-    const pieces = resource.split('!');
-    fullPath = pieces[pieces.length - 1];
-  }
-  const projectPath = fullPath.replace(rootPath, '');
-  return `.${projectPath}`;
 }

--- a/packages/hekla-core/src/Analyzer.js
+++ b/packages/hekla-core/src/Analyzer.js
@@ -5,9 +5,6 @@ const {
 
 const Module = require('./Module');
 const {
-  getModuleName
-} = require('./utils/fs-utils');
-const {
   parseAST,
   parseHTML,
   ASTWrapper,
@@ -49,8 +46,7 @@ module.exports = class Analyzer {
   }
 
   createModule(resource) {
-    const moduleName = getModuleName(resource, this.rootPath);
-    return new Module(moduleName, resource);
+    return new Module(resource, this.rootPath);
   }
 
   processModule(module) {

--- a/packages/hekla-core/src/Module.js
+++ b/packages/hekla-core/src/Module.js
@@ -1,7 +1,19 @@
+const {
+  getModuleName,
+  getModuleShortName
+} = require('./utils/fs-utils');
+
+const RESERVED_PROPERTIES = [
+  'name',
+  'shortName'
+];
+
 module.exports = class Module {
-  constructor(moduleName, resource) {
-    this._name = moduleName;
+  constructor(resource, rootPath) {
     this._resource = resource;
+    this._rootPath = rootPath;
+    this._name = getModuleName(resource, rootPath);
+    this._shortName = getModuleShortName(this._name);
     this._meta = {};
     this._error = null;
   }
@@ -15,8 +27,8 @@ module.exports = class Module {
   }
 
   set(propertyName, propertyValue) {
-    if (propertyName === 'name') {
-      throw new Error(`Cannot change a Module's name property`);
+    if(RESERVED_PROPERTIES.includes(propertyName)) {
+      throw new Error(`The '${propertyName}' property is reserved`);
     }
     this._meta[propertyName] = propertyValue;
   }
@@ -28,6 +40,7 @@ module.exports = class Module {
   serialize() {
     const result = {
       name: this._name,
+      shortName: this._shortName,
       ...this._meta
     };
     if (this._error) {

--- a/packages/hekla-core/src/Module.spec.js
+++ b/packages/hekla-core/src/Module.spec.js
@@ -5,8 +5,13 @@ describe('Module', () => {
   describe('set', () => {
 
     it('should not allow `name` to be changed', () => {
-      const module = new Module('./path/to/filename.js', '/absolute/path/to/filename.js');
+      const module = new Module('/path/to/project/src/filename.js', '/path/to/project');
       expect(() => module.set('name', 'something new')).to.throw();
+    });
+
+    it('should not allow `shortName` to be changed', () => {
+      const module = new Module('/path/to/project/src/filename.js', '/path/to/project');
+      expect(() => module.set('shortName', 'something new')).to.throw();
     });
 
   });
@@ -14,18 +19,18 @@ describe('Module', () => {
   describe('serialize', () => {
 
     it('should include custom metadata', () => {
-      const module = new Module('./path/to/filename.js', '/absolute/path/to/filename.js');
+      const module = new Module('/path/to/project/src/filename.js', '/path/to/project');
       module.set('special', true);
       const serialized = module.serialize();
       expect(serialized.special).to.equal(true);
     });
 
-    it('should put the name before everything else', () => {
-      const module = new Module('./path/to/filename.js', '/absolute/path/to/filename.js');
+    it('should put the name and shortName before everything else', () => {
+      const module = new Module('/path/to/project/src/filename.js', '/path/to/project');
       module.set('special', true);
       const serialized = module.serialize();
       const json = JSON.stringify(serialized);
-      expect(json).to.equal(`{"name":"./path/to/filename.js","special":true}`);
+      expect(json).to.equal(`{"name":"./src/filename.js","shortName":"filename.js","special":true}`);
     });
 
   });

--- a/packages/hekla-core/src/legacy/parsers/DefaultParser/index.js
+++ b/packages/hekla-core/src/legacy/parsers/DefaultParser/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const path = require('path');
+const camelCase = require('camel-case');
+
 const astUtils = require('../../../utils/ast-utils');
 const fsUtils = require('../../../utils/fs-utils');
 const BaseParser = require('../BaseParser');
@@ -29,7 +31,7 @@ function analyzeDefaultComponent(ast, module) {
 
 function getComponentDetails(module, ast) {
   return {
-    name: fsUtils.getSmartModuleName(module.path),
+    name: getSmartModuleName(module.path),
     type: 'default',
     path: module.path,
     dependencies: getDependencies(ast)
@@ -39,4 +41,29 @@ function getComponentDetails(module, ast) {
 function getDependencies(ast) {
   return astUtils.getImportInfo(ast)
     .map(importItem => importItem.value);
+}
+
+function getSmartModuleName(filePath) {
+  const pathPieces = filePath.split('/');
+  const filename = pathPieces[pathPieces.length - 1];
+  const directory = _maybeCamelCase(pathPieces[pathPieces.length - 2]);
+
+  const filePieces = filename.split('.');
+  const filenameNoExt = _maybeCamelCase(filePieces[0]);
+
+  if (filenameNoExt === 'index') {
+    return directory;
+  } else if (filenameNoExt === 'app') {
+    return directory + 'App';
+  } else {
+    return filenameNoExt;
+  }
+}
+
+function _maybeCamelCase(name) {
+  if (name.indexOf('-')) {
+    return camelCase(name);
+  } else {
+    return name;
+  }
 }

--- a/packages/hekla-core/src/utils/fs-utils/index.js
+++ b/packages/hekla-core/src/utils/fs-utils/index.js
@@ -1,16 +1,12 @@
-'use strict';
-
 const fs = require('fs');
 const path = require('path');
-const camelCase = require('camel-case');
 
 module.exports = {
   getFileExists,
   getFileContents,
   writeJSON,
   getModuleName,
-  getModuleShortName,
-  getSmartModuleName
+  getModuleShortName
 };
 
 function getFileExists(filePath) {
@@ -68,30 +64,5 @@ function getModuleShortName(moduleName) {
     return `${directory}/${filename}`;
   } else {
     return filename;
-  }
-}
-
-function getSmartModuleName(filePath) {
-  const pathPieces = filePath.split('/');
-  const filename = pathPieces[pathPieces.length - 1];
-  const directory = _maybeCamelCase(pathPieces[pathPieces.length - 2]);
-
-  const filePieces = filename.split('.');
-  const filenameNoExt = _maybeCamelCase(filePieces[0]);
-
-  if (filenameNoExt === 'index') {
-    return directory;
-  } else if (filenameNoExt === 'app') {
-    return directory + 'App';
-  } else {
-    return filenameNoExt;
-  }
-}
-
-function _maybeCamelCase(name) {
-  if (name.indexOf('-')) {
-    return camelCase(name);
-  } else {
-    return name;
   }
 }

--- a/packages/hekla-core/src/utils/fs-utils/index.js
+++ b/packages/hekla-core/src/utils/fs-utils/index.js
@@ -9,6 +9,7 @@ module.exports = {
   getFileContents,
   writeJSON,
   getModuleName,
+  getModuleShortName,
   getSmartModuleName
 };
 
@@ -53,6 +54,21 @@ function getModuleName(resource, rootPath) {
   }
   const projectPath = fullPath.replace(rootPath, '');
   return `.${projectPath}`;
+}
+
+function getModuleShortName(moduleName) {
+  const pathPieces = moduleName.split('/');
+  const filename = pathPieces[pathPieces.length - 1];
+  const directory = pathPieces[pathPieces.length - 2];
+
+  const filePieces = filename.split('.');
+  const filenameNoExt = filePieces[0];
+
+  if (['index', 'app'].includes(filenameNoExt)) {
+    return `${directory}/${filename}`;
+  } else {
+    return filename;
+  }
 }
 
 function getSmartModuleName(filePath) {

--- a/packages/hekla-core/src/utils/fs-utils/index.js
+++ b/packages/hekla-core/src/utils/fs-utils/index.js
@@ -8,6 +8,7 @@ module.exports = {
   getFileExists,
   getFileContents,
   writeJSON,
+  getModuleName,
   getSmartModuleName
 };
 
@@ -39,6 +40,19 @@ function writeJSON(data, filePath) {
       resolve();
     });
   })
+}
+
+function getModuleName(resource, rootPath) {
+  if (!rootPath) {
+    throw new Error('rootPath not specified');
+  }
+  let fullPath = resource;
+  if (fullPath.indexOf('!') !== -1) {
+    const pieces = resource.split('!');
+    fullPath = pieces[pieces.length - 1];
+  }
+  const projectPath = fullPath.replace(rootPath, '');
+  return `.${projectPath}`;
 }
 
 function getSmartModuleName(filePath) {

--- a/packages/hekla-core/src/utils/fs-utils/index.spec.js
+++ b/packages/hekla-core/src/utils/fs-utils/index.spec.js
@@ -1,6 +1,3 @@
-'use strict';
-
-const path = require('path');
 const fsUtils = require('./index');
 
 describe('fsUtils', () => {
@@ -46,35 +43,6 @@ describe('fsUtils', () => {
     it('should shorten a module named app.js', () => {
       const moduleName = './src/my-feature/app.js';
       expect(fsUtils.getModuleShortName(moduleName)).to.equal('my-feature/app.js');
-    });
-
-  });
-
-  describe('getSmartModuleName', () => {
-
-    it('should handle a normal module name', () => {
-      const filePath = '/path/to/normalModule.js';
-      expect(fsUtils.getSmartModuleName(filePath)).to.equal('normalModule');
-    });
-
-    it('should handle a module name with extra file extensions', () => {
-      const filePath = '/path/to/normalModule.thing.js';
-      expect(fsUtils.getSmartModuleName(filePath)).to.equal('normalModule');
-    });
-
-    it('should handle a module name with hyphens', () => {
-      const filePath = '/path/to/normal-module.js';
-      expect(fsUtils.getSmartModuleName(filePath)).to.equal('normalModule');
-    });
-
-    it('should handle a module named index.js', () => {
-      const filePath = '/path/to/normalModule/index.js';
-      expect(fsUtils.getSmartModuleName(filePath)).to.equal('normalModule');
-    });
-
-    it('should handle a module named app.js', () => {
-      const filePath = '/path/to/normalModule/app.js';
-      expect(fsUtils.getSmartModuleName(filePath)).to.equal('normalModuleApp');
     });
 
   });

--- a/packages/hekla-core/src/utils/fs-utils/index.spec.js
+++ b/packages/hekla-core/src/utils/fs-utils/index.spec.js
@@ -26,6 +26,30 @@ describe('fsUtils', () => {
 
   });
 
+  describe('getModuleShortName', () => {
+
+    it('should shorten a normal module name', () => {
+      const moduleName = './src/main.js';
+      expect(fsUtils.getModuleShortName(moduleName)).to.equal('main.js');
+    });
+
+    it('should shorten a module name with extra file extensions', () => {
+      const moduleName = './src/special.thing.js';
+      expect(fsUtils.getModuleShortName(moduleName)).to.equal('special.thing.js');
+    });
+
+    it('should shorten a module named index.js', () => {
+      const moduleName = './src/my-feature/index.js';
+      expect(fsUtils.getModuleShortName(moduleName)).to.equal('my-feature/index.js');
+    });
+
+    it('should shorten a module named app.js', () => {
+      const moduleName = './src/my-feature/app.js';
+      expect(fsUtils.getModuleShortName(moduleName)).to.equal('my-feature/app.js');
+    });
+
+  });
+
   describe('getSmartModuleName', () => {
 
     it('should handle a normal module name', () => {

--- a/packages/hekla-core/src/utils/fs-utils/index.spec.js
+++ b/packages/hekla-core/src/utils/fs-utils/index.spec.js
@@ -5,6 +5,27 @@ const fsUtils = require('./index');
 
 describe('fsUtils', () => {
 
+  describe('getModuleName', () => {
+
+    it('should remove the rootPath', () => {
+      const filePath = '/path/to/project/src/main.js';
+      const rootPath = '/path/to/project';
+      expect(fsUtils.getModuleName(filePath, rootPath)).to.equal('./src/main.js');
+    });
+
+    it('should remove webpack loaders from the front', () => {
+      const resourceRequest = 'module!/path/to/project/src/styles.css';
+      const rootPath = '/path/to/project';
+      expect(fsUtils.getModuleName(resourceRequest, rootPath)).to.equal('./src/styles.css');
+    });
+
+    it('should throw if rootPath is not specified', () => {
+      const filePath = '/path/to/project/src/main.js';
+      expect(() => fsUtils.getModuleName(filePath)).to.throw('rootPath not specified');
+    });
+
+  });
+
   describe('getSmartModuleName', () => {
 
     it('should handle a normal module name', () => {


### PR DESCRIPTION
This adds a new `shortName` property to each Module. The short name is usually the filename of a resource, unless it is named `index.*` or `app.*`, in which case the parent directory will be prepended.

In order to add this property, the `getModuleName` function was moved into fs-utils, and the new `getModuleShortName` function was added next to it. There was an older function called `getSmartModuleName` but it goes a different direction and we want to deprecate it. It has been inlined to the DefaultParser class, which is going to be overhauled soon anyway.

Resolves #16.