### PR TITLE
Fix breaking change to getModuleName in webpack plugin

### DIFF
--- a/packages/hekla-core/src/index.js
+++ b/packages/hekla-core/src/index.js
@@ -4,5 +4,6 @@ module.exports = {
   ConfigValidator: require('./ConfigValidator'),
   DependencyGraph: require('./utils/dependency-graph'),
   astUtils: require('./utils/ast-utils'),
+  fsUtils: require('./utils/fs-utils'),
   plugins: require('./plugins')
 };

--- a/packages/hekla-webpack-plugin/src/HeklaWebpackPlugin.js
+++ b/packages/hekla-webpack-plugin/src/HeklaWebpackPlugin.js
@@ -5,6 +5,7 @@ const {
   Analyzer,
   ConfigValidator
 } = require('hekla-core');
+const { getModuleName } = require('hekla-core').fsUtils;
 
 const WORKER_COUNT = 5;
 const BAIL_ON_ERROR = false; // for debugging purposes
@@ -58,7 +59,7 @@ module.exports = class HeklaWebpackPlugin {
     }
 
     const sanitizedResource = resource.replace(/\?.*$/, '');
-    const moduleName = this.analyzer.getModuleName(sanitizedResource);
+    const moduleName = getModuleName(sanitizedResource, this.analyzer.rootPath);
 
     if (moduleName.match(/node_modules/)) {
       return;


### PR DESCRIPTION
The `Analyzer#getModuleName` method was removed, but the webpack plugin relied on it for comparing module names to exclude patterns. This replaces the broken usage with the new `getModuleName` function from fsUtils.