### PR TITLE
Enable babel flag for optionalCatchBinding

### DIFF
--- a/packages/hekla-core/src/utils/ast-utils/index.js
+++ b/packages/hekla-core/src/utils/ast-utils/index.js
@@ -39,6 +39,7 @@ function parseAST(fileContents, filePath) {
         'classProperties',
         'jsx',
         'typescript',
+        'optionalCatchBinding',
       ]
     });
     return Promise.resolve(ast);


### PR DESCRIPTION
This enables the babel flag for `optionalCatchBinding`. It lets us parse some extra JS syntax that we couldn't before.