### PR TITLE
Support webpack 3

### DIFF
--- a/packages/hekla-webpack-plugin/README.md
+++ b/packages/hekla-webpack-plugin/README.md
@@ -4,6 +4,8 @@ Webpack integration for running static analysis with Hekla
 
 [![Build Status](https://travis-ci.org/andrewjensen/hekla.svg?branch=master)](https://travis-ci.org/andrewjensen/hekla)
 
+Supports Webpack v3 and above.
+
 ## Quick setup
 
 ### Step 1: Add the dependencies to your `package.json` file:


### PR DESCRIPTION
This adds support for webpack 3. It works by checking if hooks are available directly (webpack 4+), and if not, using the `plugin()` API from webpack 3.