### PR TITLE
Modularize workers and renderers

### DIFF
--- a/packages/hekla-core/package-lock.json
+++ b/packages/hekla-core/package-lock.json
@@ -19,6 +19,14 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -76,11 +84,34 @@
 				"type-detect": "^4.0.0"
 			}
 		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
 			"dev": true
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"commander": {
 			"version": "2.15.1",
@@ -173,8 +204,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"esutils": {
 			"version": "2.0.2",
@@ -214,8 +244,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"he": {
 			"version": "1.1.1",
@@ -380,6 +409,11 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
+		"sticky-terminal-display": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/sticky-terminal-display/-/sticky-terminal-display-0.1.0.tgz",
+			"integrity": "sha512-y8+CjknYKj2F8uIls26KJCsqxDF5l8cD4Jx0H2rVkeEJe5AmF5xbaL34lrZdugMBzJJEjX3waRTawP7MDuA73Q=="
+		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -392,7 +426,6 @@
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}

--- a/packages/hekla-core/package.json
+++ b/packages/hekla-core/package.json
@@ -14,11 +14,13 @@
     "@babel/types": "^7.1.2",
     "async": "^2.1.2",
     "camel-case": "^3.0.0",
+    "chalk": "^2.4.2",
     "dashify": "^0.2.2",
     "domhandler": "^2.4.2",
     "glob": "^7.1.4",
     "htmlparser2": "^3.9.1",
     "minimatch": "^3.0.4",
+    "sticky-terminal-display": "^0.1.0",
     "tapable": "^1.1.0",
     "tree-walk": "^0.4.0"
   },

--- a/packages/hekla-core/src/Analyzer.js
+++ b/packages/hekla-core/src/Analyzer.js
@@ -59,7 +59,6 @@ module.exports = class Analyzer {
 
   async run() {
     this.startWorkers(DEFAULT_WORKER_COUNT);
-    this.sendStatusUpdate(analysisStarted(DEFAULT_WORKER_COUNT));
 
     const files = await getProjectFiles(this.config.rootPath, {
       ignorePatterns: this.config.exclude || []
@@ -72,7 +71,6 @@ module.exports = class Analyzer {
     }
 
     await this.waitForWorkers();
-    this.sendStatusUpdate(analysisSuccessful());
   }
 
   startWorkers(workerCount) {
@@ -80,10 +78,12 @@ module.exports = class Analyzer {
     this.workQueue.onStatusUpdate(message => this.sendStatusUpdate(message));
 
     this.workQueue.start(workerCount);
+    this.sendStatusUpdate(analysisStarted(DEFAULT_WORKER_COUNT));
   }
 
   async waitForWorkers() {
     await this.workQueue.waitForFinish();
+    this.sendStatusUpdate(analysisSuccessful());
   }
 
   createModule(resource) {

--- a/packages/hekla-core/src/Analyzer.js
+++ b/packages/hekla-core/src/Analyzer.js
@@ -90,7 +90,7 @@ module.exports = class Analyzer {
   }
 
   queueProcessModule(module) {
-    this.workQueue.enqueue(module.getName(), module.getResource());
+    this.workQueue.enqueue(module);
   }
 
   processModule(module) {

--- a/packages/hekla-core/src/Analyzer.js
+++ b/packages/hekla-core/src/Analyzer.js
@@ -4,6 +4,11 @@ const {
 } = require('tapable');
 
 const Module = require('./Module');
+const WorkQueue = require('./WorkQueue');
+const {
+  analysisStarted,
+  analysisSuccessful,
+} = require('./StatusMessage');
 const {
   getProjectFiles
 } = require('./utils/fs-utils');
@@ -14,15 +19,19 @@ const {
   DOMWrapper
 } = require('./utils/ast-utils');
 
+const DEFAULT_WORKER_COUNT = 5;
+
 module.exports = class Analyzer {
   constructor() {
     this.config = null;
     this.fs = null;
     this.modules = [];
+    this.workQueue = null;
     this.hooks = {
       moduleRawSource: new SyncHook(['module', 'source']),
       moduleSyntaxTreeJS: new SyncHook(['module', 'ast']),
       moduleSyntaxTreeHTML: new SyncHook(['module', 'dom']),
+      statusUpdate: new SyncHook(['message']),
       reporter: new AsyncSeriesHook(['analyzer', 'analysis'])
     };
   }
@@ -49,19 +58,40 @@ module.exports = class Analyzer {
   }
 
   async run() {
+    this.startWorkers(DEFAULT_WORKER_COUNT);
+    this.sendStatusUpdate(analysisStarted(DEFAULT_WORKER_COUNT));
+
     const files = await getProjectFiles(this.config.rootPath, {
       ignorePatterns: this.config.exclude || []
     });
 
     for (let file of files) {
-      // TODO: use worker queue to parallelize this
       const fileModule = this.createModule(file);
-      await this.processModule(fileModule);
+      // await this.processModule(fileModule);
+      this.queueProcessModule(fileModule);
     }
+
+    await this.waitForWorkers();
+    this.sendStatusUpdate(analysisSuccessful());
+  }
+
+  startWorkers(workerCount) {
+    this.workQueue = new WorkQueue(this);
+    this.workQueue.onStatusUpdate(message => this.sendStatusUpdate(message));
+
+    this.workQueue.start(workerCount);
+  }
+
+  async waitForWorkers() {
+    await this.workQueue.waitForFinish();
   }
 
   createModule(resource) {
     return new Module(resource, this.config.rootPath);
+  }
+
+  queueProcessModule(module) {
+    this.workQueue.enqueue(module.getName(), module.getResource());
   }
 
   processModule(module) {
@@ -103,6 +133,10 @@ module.exports = class Analyzer {
 
   processModuleSource(module, source) {
     this.hooks.moduleRawSource.call(module, source);
+  }
+
+  sendStatusUpdate(message) {
+    this.hooks.statusUpdate.call(message);
   }
 
   processReporters(analysis) {

--- a/packages/hekla-core/src/Analyzer.js
+++ b/packages/hekla-core/src/Analyzer.js
@@ -66,7 +66,6 @@ module.exports = class Analyzer {
 
     for (let file of files) {
       const fileModule = this.createModule(file);
-      // await this.processModule(fileModule);
       this.queueProcessModule(fileModule);
     }
 

--- a/packages/hekla-core/src/StatusMessage.js
+++ b/packages/hekla-core/src/StatusMessage.js
@@ -1,0 +1,62 @@
+const TYPES = {
+  'STATUS_ANALYSIS_STARTED': 'STATUS_ANALYSIS_STARTED',
+  'STATUS_ANALYSIS_SUCCESSFUL': 'STATUS_ANALYSIS_SUCCESSFUL',
+  'STATUS_ANALYSIS_FAILED': 'STATUS_ANALYSIS_FAILED',
+  'STATUS_MODULE_QUEUED': 'STATUS_MODULE_QUEUED',
+  'STATUS_MODULE_SUCCESSFUL': 'STATUS_MODULE_SUCCESSFUL',
+  'STATUS_MODULE_FAILED': 'STATUS_MODULE_FAILED',
+};
+
+const analysisStarted = (workerCount) => ({
+  type: TYPES.STATUS_ANALYSIS_STARTED,
+  payload: {
+    workerCount
+  }
+});
+
+const analysisSuccessful = () => ({
+  type: TYPES.STATUS_ANALYSIS_SUCCESSFUL,
+  payload: {}
+});
+
+const analysisFailed = (error) => ({
+  type: TYPES.STATUS_ANALYSIS_FAILED,
+  payload: {
+    error
+  }
+});
+
+const moduleQueued = (moduleName, workerIdx) => ({
+  type: TYPES.STATUS_MODULE_QUEUED,
+  payload: {
+    moduleName,
+    workerIdx
+  }
+});
+
+const moduleSuccessful = (moduleName, workerIdx) => ({
+  type: TYPES.STATUS_MODULE_SUCCESSFUL,
+  payload: {
+    moduleName,
+    workerIdx
+  }
+});
+
+const moduleFailed = (moduleName, workerIdx, error) => ({
+  type: TYPES.STATUS_MODULE_FAILED,
+  payload: {
+    moduleName,
+    workerIdx,
+    error
+  }
+});
+
+module.exports = {
+  TYPES,
+  analysisStarted,
+  analysisSuccessful,
+  analysisFailed,
+  moduleQueued,
+  moduleSuccessful,
+  moduleFailed,
+};

--- a/packages/hekla-core/src/StatusMessage.js
+++ b/packages/hekla-core/src/StatusMessage.js
@@ -26,27 +26,27 @@ const analysisFailed = (error) => ({
   }
 });
 
-const moduleQueued = (moduleName, workerIdx) => ({
+const moduleQueued = (moduleName, workerId) => ({
   type: TYPES.STATUS_MODULE_QUEUED,
   payload: {
     moduleName,
-    workerIdx
+    workerId
   }
 });
 
-const moduleSuccessful = (moduleName, workerIdx) => ({
+const moduleSuccessful = (moduleName, workerId) => ({
   type: TYPES.STATUS_MODULE_SUCCESSFUL,
   payload: {
     moduleName,
-    workerIdx
+    workerId
   }
 });
 
-const moduleFailed = (moduleName, workerIdx, error) => ({
+const moduleFailed = (moduleName, workerId, error) => ({
   type: TYPES.STATUS_MODULE_FAILED,
   payload: {
     moduleName,
-    workerIdx,
+    workerId,
     error
   }
 });

--- a/packages/hekla-core/src/WorkQueue.js
+++ b/packages/hekla-core/src/WorkQueue.js
@@ -31,13 +31,12 @@ module.exports = class WorkQueue {
     };
   }
 
-  // TODO: refactor to handle Modules
-  enqueue(moduleName, resource) {
+  enqueue(module) {
     if (!this.started) {
       throw new Error('WorkQueue has not been started yet');
     }
 
-    this.queue.push(makeTask(moduleName, resource))
+    this.queue.push(makeTask(module))
   }
 
   async waitForFinish() {
@@ -65,8 +64,7 @@ module.exports = class WorkQueue {
 
   async _queueWorker(task) {
     this.queueWorking = true;
-    const { moduleName, resource } = task;
-    let module = this.analyzer.createModule(resource);
+    const { module } = task;
 
     const workerId = this._claimWorkerId();
 
@@ -110,6 +108,6 @@ module.exports = class WorkQueue {
   }
 }
 
-function makeTask(moduleName, resource) {
-  return { moduleName, resource };
+function makeTask(module) {
+  return { module };
 }

--- a/packages/hekla-core/src/WorkQueue.js
+++ b/packages/hekla-core/src/WorkQueue.js
@@ -1,0 +1,93 @@
+const asyncLib = require('async');
+
+const {
+  moduleQueued,
+  moduleSuccessful,
+  moduleFailed
+} = require('./StatusMessage');
+
+module.exports = class WorkQueue {
+  constructor(analyzer) {
+    this.analyzer = analyzer;
+    this.statusCallbacks = [];
+    this.started = false;
+  }
+
+  start(workerCount) {
+    this.started = true;
+    this.workerCount = workerCount;
+
+    this.queueWorking = true;
+    this.queueDrainResolver = null;
+    this.queueDrainRejecter = null;
+
+    this.queue = asyncLib.queue(this._queueWorker.bind(this), workerCount);
+    this.queue.drain = () => {
+      this.queueWorking = false;
+      if (this.queueDrainResolver) {
+        this.queueDrainResolver();
+      }
+    };
+  }
+
+  // TODO: refactor to handle Modules
+  enqueue(moduleName, resource) {
+    if (!this.started) {
+      throw new Error('WorkQueue has not been started yet');
+    }
+
+    this.queue.push(makeTask(moduleName, resource))
+  }
+
+  async waitForFinish() {
+    if (!this.queueWorking) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve, reject) => {
+      this.queueDrainResolver = resolve;
+      this.queueDrainRejecter = reject;
+    });
+  }
+
+  onStatusUpdate(callback) {
+    this.statusCallbacks.push(callback);
+
+    // Return an unsubscribe function
+    return () => {
+      this.statusCallbacks = this.statusCallbacks
+        .filter(cb => cb !== callback);
+    }
+  }
+
+  // Private methods
+
+  async _queueWorker(task) {
+    this.queueWorking = true;
+    const { moduleName, resource } = task;
+
+    // TODO: get the actual worker index
+    const workerIdx = 0;
+
+    let module = this.analyzer.createModule(resource);
+
+    try {
+      this._sendStatusUpdate(moduleQueued(module.getName(), workerIdx));
+
+      await this.analyzer.processModule(module);
+      this._sendStatusUpdate(moduleSuccessful(module.getName(), workerIdx));
+    } catch (err) {
+      this._sendStatusUpdate(moduleFailed(module.getName(), workerIdx, err));
+    }
+  }
+
+  _sendStatusUpdate(statusMessage) {
+    for (let callback of this.statusCallbacks) {
+      callback(statusMessage);
+    }
+  }
+}
+
+function makeTask(moduleName, resource) {
+  return { moduleName, resource };
+}

--- a/packages/hekla-core/src/WorkQueue.spec.js
+++ b/packages/hekla-core/src/WorkQueue.spec.js
@@ -2,11 +2,6 @@ const WorkQueue = require('./WorkQueue');
 const Module = require('./Module');
 
 class MockAnalyzer {
-  // TODO: remove from mock after changing the interface
-  createModule(resource) {
-    return new Module(resource, '/path/to/project');
-  }
-
   async processModule(module) {
     await sleep(10);
   }
@@ -28,8 +23,9 @@ describe('WorkQueue', () => {
     });
     queue.start(2);
 
-    queue.enqueue('truck.js', '/path/to/project/src/truck.js');
-    queue.enqueue('bus.js', '/path/to/project/src/bus.js');
+    const rootPath = '/path/to/project';
+    queue.enqueue(new Module('/path/to/project/src/truck.js', rootPath));
+    queue.enqueue(new Module('/path/to/project/src/bus.js', rootPath));
 
     await queue.waitForFinish();
 

--- a/packages/hekla-core/src/WorkQueue.spec.js
+++ b/packages/hekla-core/src/WorkQueue.spec.js
@@ -1,0 +1,68 @@
+const WorkQueue = require('./WorkQueue');
+const Module = require('./Module');
+
+class MockAnalyzer {
+  // TODO: remove from mock after changing the interface
+  createModule(resource) {
+    return new Module(resource, '/path/to/project');
+  }
+
+  async processModule(module) {
+    await sleep(10);
+  }
+}
+
+async function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('WorkQueue', () => {
+
+  it('sends status updates', async () => {
+    const messages = [];
+
+    const analyzer = new MockAnalyzer();
+    const queue = new WorkQueue(analyzer);
+    queue.onStatusUpdate(statusMessage => {
+      messages.push(statusMessage);
+    });
+    queue.start(2);
+
+    queue.enqueue('truck.js', '/path/to/project/src/truck.js');
+    queue.enqueue('bus.js', '/path/to/project/src/bus.js');
+
+    await queue.waitForFinish();
+
+    expect(messages).to.deep.equal([
+      {
+        type: 'STATUS_MODULE_QUEUED',
+        payload: {
+          moduleName: './src/truck.js',
+          workerIdx: 0
+        }
+      },
+      {
+        type: 'STATUS_MODULE_QUEUED',
+        payload: {
+          moduleName: './src/bus.js',
+          workerIdx: 0
+        }
+      },
+      {
+        type: 'STATUS_MODULE_SUCCESSFUL',
+        payload: {
+          moduleName: './src/truck.js',
+          workerIdx: 0
+        }
+      },
+      {
+        type: 'STATUS_MODULE_SUCCESSFUL',
+        payload: {
+          moduleName: './src/bus.js',
+          workerIdx: 0
+        }
+      }
+    ]);
+  });
+
+});

--- a/packages/hekla-core/src/WorkQueue.spec.js
+++ b/packages/hekla-core/src/WorkQueue.spec.js
@@ -38,28 +38,28 @@ describe('WorkQueue', () => {
         type: 'STATUS_MODULE_QUEUED',
         payload: {
           moduleName: './src/truck.js',
-          workerIdx: 0
+          workerId: 0
         }
       },
       {
         type: 'STATUS_MODULE_QUEUED',
         payload: {
           moduleName: './src/bus.js',
-          workerIdx: 0
+          workerId: 1
         }
       },
       {
         type: 'STATUS_MODULE_SUCCESSFUL',
         payload: {
           moduleName: './src/truck.js',
-          workerIdx: 0
+          workerId: 0
         }
       },
       {
         type: 'STATUS_MODULE_SUCCESSFUL',
         payload: {
           moduleName: './src/bus.js',
-          workerIdx: 0
+          workerId: 1
         }
       }
     ]);

--- a/packages/hekla-core/src/plugins/StatusUpdatePlugin.js
+++ b/packages/hekla-core/src/plugins/StatusUpdatePlugin.js
@@ -10,21 +10,29 @@ module.exports = class StatusUpdatePlugin {
   }
 
   onStatusUpdate(message) {
-    switch (message.type) {
-      case TYPES.STATUS_ANALYSIS_STARTED:
-        return this.analysisStarted(message.payload.workerCount);
+    try {
+      switch (message.type) {
+        case TYPES.STATUS_ANALYSIS_STARTED:
+          return this.analysisStarted(message.payload.workerCount);
 
-      case TYPES.STATUS_ANALYSIS_SUCCESSFUL:
-        return this.analysisSuccessful();
+        case TYPES.STATUS_ANALYSIS_SUCCESSFUL:
+          return this.analysisSuccessful();
 
-      case TYPES.STATUS_MODULE_QUEUED:
-        return this.moduleQueued(message.payload.moduleName, message.payload.workerId);
+        case TYPES.STATUS_MODULE_QUEUED:
+          return this.moduleQueued(message.payload.moduleName, message.payload.workerId);
 
-      case TYPES.STATUS_MODULE_SUCCESSFUL:
-        return this.moduleSuccessful(message.payload.workerId);
+        case TYPES.STATUS_MODULE_SUCCESSFUL:
+          return this.moduleSuccessful(message.payload.workerId);
 
-      default:
-        throw new Exception(`Unhandled status update type: ${message.type}`);
+        case TYPES.STATUS_MODULE_FAILED:
+            return this.moduleFailed(message.payload.workerId);
+
+        default:
+          throw new Exception(`Unhandled status update type: ${message.type}`);
+      }
+    } catch (err) {
+      console.log('Error in event handler:', err);
+      throw err;
     }
   }
 
@@ -65,6 +73,14 @@ module.exports = class StatusUpdatePlugin {
       .write(`  ${chalk.bold(`Worker ${workerId + 1}`)}: free`);
 
     this.stats.completed++;
+    this.printSummary();
+  }
+
+  moduleFailed(workerId) {
+    this.getWorkerRenderer(workerId)
+      .write(`  ${chalk.bold(`Worker ${workerId + 1}`)}: free`);
+
+    this.stats.errors++;
     this.printSummary();
   }
 

--- a/packages/hekla-core/src/plugins/StatusUpdatePlugin.js
+++ b/packages/hekla-core/src/plugins/StatusUpdatePlugin.js
@@ -1,0 +1,81 @@
+const chalk = require('chalk');
+const StickyTerminalDisplay = require('sticky-terminal-display');
+const { TYPES } = require('../StatusMessage');
+
+module.exports = class StatusUpdatePlugin {
+  apply(analyzer) {
+    analyzer.hooks.statusUpdate.tap('StatusUpdatePlugin', this.onStatusUpdate.bind(this));
+  }
+
+  onStatusUpdate(message) {
+    switch (message.type) {
+      case TYPES.STATUS_ANALYSIS_STARTED:
+        return this.analysisStarted(message.payload.workerCount);
+
+      case TYPES.STATUS_ANALYSIS_SUCCESSFUL:
+        return this.analysisSuccessful();
+
+      case TYPES.STATUS_MODULE_QUEUED:
+        return this.moduleQueued(message.payload.moduleName, message.payload.workerId);
+
+      case TYPES.STATUS_MODULE_SUCCESSFUL:
+        return this.moduleSuccessful(message.payload.workerId);
+
+      default:
+        throw new Exception(`Unhandled status update type: ${message.type}`);
+    }
+  }
+
+  // Event handlers
+
+  analysisStarted(workerCount) {
+    this.workerCount = workerCount;
+    this.stats = {
+      completed: 0,
+      errors: 0,
+      found: 0
+    };
+
+    const display = new StickyTerminalDisplay();
+
+    this.summaryRenderer = display.getLineRenderer();
+
+    this.workerRenderers = [];
+    for (let i = 0; i < workerCount; i++) {
+      const renderer = display.getLineRenderer();
+      this.workerRenderers.push(renderer);
+    }
+  }
+
+  analysisSuccessful() {
+    console.log('Done.');
+  }
+
+  moduleQueued(moduleName, workerId) {
+    this.getWorkerRenderer(workerId)
+      .write(`  ${chalk.bold(`Worker ${workerId + 1}`)}: ${moduleName}`);
+
+    this.stats.found++;
+    this.printSummary();
+  }
+
+  moduleSuccessful(workerId) {
+    this.getWorkerRenderer(workerId)
+      .write(`  ${chalk.bold(`Worker ${workerId + 1}`)}: free`);
+
+    this.stats.completed++;
+    this.printSummary();
+  }
+
+  // Rendering helpers
+
+  printSummary() {
+    const { completed, errors, found } = this.stats;
+    const processed = completed + errors;
+    this.summaryRenderer.write(`Hekla: processed ${processed}/${found} modules with ${errors} errors`);
+  }
+
+  getWorkerRenderer(workerId) {
+    return this.workerRenderers[workerId];
+  }
+}

--- a/packages/hekla-core/src/plugins/StatusUpdatePlugin.js
+++ b/packages/hekla-core/src/plugins/StatusUpdatePlugin.js
@@ -2,6 +2,8 @@ const chalk = require('chalk');
 const StickyTerminalDisplay = require('sticky-terminal-display');
 const { TYPES } = require('../StatusMessage');
 
+const MAX_MODULE_NAME_LENGTH = 80;
+
 module.exports = class StatusUpdatePlugin {
   apply(analyzer) {
     analyzer.hooks.statusUpdate.tap('StatusUpdatePlugin', this.onStatusUpdate.bind(this));
@@ -35,7 +37,6 @@ module.exports = class StatusUpdatePlugin {
       errors: 0,
       found: 0
     };
-
     const display = new StickyTerminalDisplay();
 
     this.summaryRenderer = display.getLineRenderer();
@@ -48,12 +49,12 @@ module.exports = class StatusUpdatePlugin {
   }
 
   analysisSuccessful() {
-    console.log('Done.');
   }
 
   moduleQueued(moduleName, workerId) {
+    const truncatedModuleName = truncateStringRight(moduleName, MAX_MODULE_NAME_LENGTH);
     this.getWorkerRenderer(workerId)
-      .write(`  ${chalk.bold(`Worker ${workerId + 1}`)}: ${moduleName}`);
+      .write(`  ${chalk.bold(`Worker ${workerId + 1}`)}: ${truncatedModuleName}`);
 
     this.stats.found++;
     this.printSummary();
@@ -78,4 +79,13 @@ module.exports = class StatusUpdatePlugin {
   getWorkerRenderer(workerId) {
     return this.workerRenderers[workerId];
   }
+}
+
+function truncateStringRight(input, maxLength) {
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  const truncated = input.substring(input.length - maxLength + 3);
+  return `...${truncated}`;
 }

--- a/packages/hekla-core/src/plugins/index.js
+++ b/packages/hekla-core/src/plugins/index.js
@@ -1,9 +1,11 @@
 const LinesOfCodePlugin = require('./LinesOfCodePlugin');
 const ListImportsPlugin = require('./ListImportsPlugin');
 const OwnershipPlugin = require('./OwnershipPlugin');
+const StatusUpdatePlugin = require('./StatusUpdatePlugin');
 
 module.exports = {
   LinesOfCodePlugin,
   ListImportsPlugin,
-  OwnershipPlugin
+  OwnershipPlugin,
+  StatusUpdatePlugin
 };

--- a/packages/hekla-webpack-plugin/package-lock.json
+++ b/packages/hekla-webpack-plugin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "hekla-webpack-plugin",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -140,8 +140,7 @@
 		"@babel/parser": {
 			"version": "7.4.5",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-			"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
-			"dev": true
+			"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
 			"version": "7.2.0",
@@ -201,7 +200,6 @@
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
 			"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.11",
@@ -777,6 +775,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -1168,11 +1167,11 @@
 			"dev": true
 		},
 		"async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"async-each": {
@@ -1313,11 +1312,6 @@
 				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
 				"babel-plugin-jest-hoist": "^24.6.0"
 			}
-		},
-		"babylon": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -1700,6 +1694,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -1939,6 +1934,7 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1946,7 +1942,8 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -2465,7 +2462,8 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.11.1",
@@ -2523,8 +2521,7 @@
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"events": {
 			"version": "1.1.1",
@@ -3523,7 +3520,8 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.0",
@@ -3612,16 +3610,19 @@
 			}
 		},
 		"hekla-core": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/hekla-core/-/hekla-core-0.1.0.tgz",
-			"integrity": "sha1-BiJzyW5oj+tc0qNQgzAoTx1DMmk=",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/hekla-core/-/hekla-core-0.2.0.tgz",
+			"integrity": "sha512-eYQwHIdUWTdQd9S2QVtUe6JHU+3i6l50PxNoQu+grZIvCT6w32SdXXj9wfxXln097vW0pQmRQVljRkNEEaLq5A==",
 			"requires": {
+				"@babel/parser": "^7.0.0",
+				"@babel/types": "^7.1.2",
 				"async": "^2.1.2",
-				"babylon": "^6.8.4",
 				"camel-case": "^3.0.0",
 				"dashify": "^0.2.2",
+				"domhandler": "^2.4.2",
 				"glob": "^7.0.5",
 				"htmlparser2": "^3.9.1",
+				"tapable": "^1.1.0",
 				"tree-walk": "^0.4.0"
 			}
 		},
@@ -7273,11 +7274,6 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
-		"sticky-terminal-display": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/sticky-terminal-display/-/sticky-terminal-display-0.1.0.tgz",
-			"integrity": "sha512-y8+CjknYKj2F8uIls26KJCsqxDF5l8cD4Jx0H2rVkeEJe5AmF5xbaL34lrZdugMBzJJEjX3waRTawP7MDuA73Q=="
-		},
 		"stream-browserify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
@@ -7404,6 +7400,7 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -7417,8 +7414,7 @@
 		"tapable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
-			"integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA==",
-			"dev": true
+			"integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA=="
 		},
 		"test-exclude": {
 			"version": "5.2.3",
@@ -7472,8 +7468,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",

--- a/packages/hekla-webpack-plugin/package.json
+++ b/packages/hekla-webpack-plugin/package.json
@@ -9,10 +9,7 @@
   "author": "Andrew Jensen <andrewjensen90@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "async": "^2.6.1",
-    "chalk": "^2.4.1",
-    "hekla-core": "^0.2.0",
-    "sticky-terminal-display": "^0.1.0"
+    "hekla-core": "^0.2.0"
   },
   "devDependencies": {
     "jest": "^24.8.0",


### PR DESCRIPTION
This refactors the worker logic from `hekla-webpack-plugin` and moves it into the core, as a new `WorkQueue` class. Running analysis now starts a batch of workers that will asynchronously consume from a queue of modules. The rendering logic has been refactored into a new `StatusUpdatePlugin`, which can be used from within either the CLI or the webpack plugin.

Closes #20.