### PR TITLE
Run all available tests on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A toolset to make large JS codebases more understandable",
   "main": "index.js",
   "scripts": {
-    "test": "cd packages/hekla-core/ && npm test",
+    "test": "lerna run test-ci",
     "postinstall": "lerna bootstrap"
   },
   "repository": {

--- a/packages/hekla-core/package.json
+++ b/packages/hekla-core/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "mocha src/**/*.spec.js --require ./test/test-helpers.js",
+    "test-ci": "npm run test",
     "tdd": "mocha src/**/*.spec.js --require ./test/test-helpers.js --reporter min --watch"
   },
   "author": "Andrew Jensen <andrewjensen90@gmail.com>",

--- a/packages/hekla-webpack-plugin/package.json
+++ b/packages/hekla-webpack-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test-ci": "CI=true jest"
   },
   "author": "Andrew Jensen <andrewjensen90@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This changes the top-level package to run the tests for subpackages, using the `lerna run test-ci` command. This means that we need to define a `test-ci` script for every subpackage that has tests to run during CI. For now, that is `hekla-core` and `hekla-webpack-plugin`.